### PR TITLE
building app in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+
+WORKDIR /app
+
+COPY pom.xml .
+COPY src ./src
+
+RUN mvn clean install -DskipTests
+
+
+
 FROM openjdk:21-jdk-slim
 
 WORKDIR /app


### PR DESCRIPTION
Added multi-stage Dockerfile that builds the Spring Boot project using Maven inside a container. This allows building and running the app without requiring Java 21 or Maven to be installed locally.